### PR TITLE
添加MacOS下的守护进程方式

### DIFF
--- a/docs/guide/install/manual.md
+++ b/docs/guide/install/manual.md
@@ -36,7 +36,7 @@ chmod +x alist
 # Get admin's info
 ./alist admin
 ```
-@tab macos
+@tab macOS
 ```bash
 # Unzip the downloaded file to get the executable file:
 tar -zxvf alist-xxxx.tar.gz
@@ -47,7 +47,7 @@ chmod +x alist
 # Get admin's info
 ./alist admin
 ```
-@tab windows
+@tab Windows
 ```bash
 # Unzip the downloaded file to get the executable file:
 unzip alist-xxxx.zip
@@ -82,8 +82,10 @@ alist restart
 ```
 :::
 
-### Daemon(Linux)
+### Daemon
 
+:::tabs#os
+@tab linux
 `vim /usr/lib/systemd/system/alist.service` add the following content, where path_alist is the path where alist is located
 ```ini
 [Unit]
@@ -106,7 +108,41 @@ Then `systemctl daemon-reload`, now you can use these commands to manage the pro
 - Cancel Self-start: `systemctl disable alist`
 - Status: `systemctl status alist`
 - Restart: `systemctl restart alist`
+@tab macos
+Edit `~/Library/LaunchAgents/ci.nn.alist.plist` in any way and add the following content, modify `path_alist` to be the path where AList is located, and `path/to/working/dir` to be the working path of AList
 
+```conf
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+     <dict>
+         <key>Label</key>
+         <string>ci.nn.alist</string>
+         <key>KeepAlive</key>
+         <true/>
+         <key>ProcessType</key>
+         <string>Background</string>
+         <key>RunAtLoad</key>
+         <true/>
+         <key>WorkingDirectory</key>
+         <string>path/to/working/dir</string>
+         <key>ProgramArguments</key>
+         <array>
+             <string>path_alist/alist</string>
+             <string>server</string>
+         </array>
+     </dict>
+</plist>
+```
+
+Then, execute `launchctl load ~/Library/LaunchAgents/ci.nn.alist` to load the configuration, now you can use these commands to manage the program:
+
+- Start: `launchctl start ~/Library/LaunchAgents/ci.nn.alist`
+- Close: `launchctl stop ~/Library/LaunchAgents/ci.nn.alist`
+- Unload configuration: `launchctl unload ~/Library/LaunchAgents/ci.nn.alist`
+@tab windows
+Any way you know and it is no longer provided here.
+:::
 
 
 ### How to update

--- a/docs/guide/install/manual.md
+++ b/docs/guide/install/manual.md
@@ -108,10 +108,11 @@ Then `systemctl daemon-reload`, now you can use these commands to manage the pro
 - Cancel Self-start: `systemctl disable alist`
 - Status: `systemctl status alist`
 - Restart: `systemctl restart alist`
-@tab macos
+
+@tab macOS
 Edit `~/Library/LaunchAgents/ci.nn.alist.plist` in any way and add the following content, modify `path_alist` to be the path where AList is located, and `path/to/working/dir` to be the working path of AList
 
-```conf
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -140,8 +141,11 @@ Then, execute `launchctl load ~/Library/LaunchAgents/ci.nn.alist` to load the co
 - Start: `launchctl start ~/Library/LaunchAgents/ci.nn.alist`
 - Close: `launchctl stop ~/Library/LaunchAgents/ci.nn.alist`
 - Unload configuration: `launchctl unload ~/Library/LaunchAgents/ci.nn.alist`
-@tab windows
+
+@tab Windows
+
 Any way you know and it is no longer provided here.
+
 :::
 
 

--- a/docs/zh/guide/install/manual.md
+++ b/docs/zh/guide/install/manual.md
@@ -110,7 +110,7 @@ WantedBy=multi-user.target
 
 ### 守护进程(MacOS)
 
-使用任意方式编辑 `~/Library/LaunchAgents/ci.nn.alist` 并添加如下内容，修改 `path_alist` 为 AList 所在的路径，`path/to/working/dir` 为 AList的工作路径
+使用任意方式编辑 `~/Library/LaunchAgents/ci.nn.alist.plist` 并添加如下内容，修改 `path_alist` 为 AList 所在的路径，`path/to/working/dir` 为 AList的工作路径
 
 ```conf
 <?xml version="1.0" encoding="UTF-8"?>

--- a/docs/zh/guide/install/manual.md
+++ b/docs/zh/guide/install/manual.md
@@ -108,7 +108,39 @@ WantedBy=multi-user.target
 - 状态: `systemctl status alist`
 - 重启: `systemctl restart alist`
 
+### 守护进程(MacOS)
 
+使用任意方式编辑 `~/Library/LaunchAgents/ci.nn.alist` 并添加如下内容，修改 `path_alist` 为 AList 所在的路径，`path/to/working/dir` 为 AList的工作路径
+
+```conf
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Label</key>
+        <string>ci.nn.alist</string>
+        <key>KeepAlive</key>
+        <true/>
+        <key>ProcessType</key>
+        <string>Background</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>WorkingDirectory</key>
+        <string>path/to/working/dir</string>
+        <key>ProgramArguments</key>
+        <array>
+            <string>path_alist/alist</string>
+            <string>server</string>
+        </array>
+    </dict>
+</plist>
+```
+
+然后，执行 `launchctl load ~/Library/LaunchAgents/ci.nn.alist` 加载配置，现在你可以使用这些命令来管理程序：
+
+- 开启: `launchctl start ~/Library/LaunchAgents/ci.nn.alist`
+- 关闭: `launchctl stop ~/Library/LaunchAgents/ci.nn.alist`
+- 卸载配置: `launchctl unload ~/Library/LaunchAgents/ci.nn.alist`
 
 ### 如何更新
 

--- a/docs/zh/guide/install/manual.md
+++ b/docs/zh/guide/install/manual.md
@@ -80,7 +80,7 @@ alist restart
 ```
 :::
 
-### 守护进程(Linux)
+### 守护进程
 
 :::tabs#os
 @tab Linux

--- a/docs/zh/guide/install/manual.md
+++ b/docs/zh/guide/install/manual.md
@@ -82,6 +82,8 @@ alist restart
 
 ### 守护进程(Linux)
 
+:::tabs#os
+@tab Linux
 使用任意方式编辑 `/usr/lib/systemd/system/alist.service` 并添加如下内容，其中 path_alist 为 AList 所在的路径
 
 ```conf
@@ -107,9 +109,7 @@ WantedBy=multi-user.target
 - 取消开机自启: `systemctl disable alist`
 - 状态: `systemctl status alist`
 - 重启: `systemctl restart alist`
-
-### 守护进程(MacOS)
-
+@tab macOS
 使用任意方式编辑 `~/Library/LaunchAgents/ci.nn.alist.plist` 并添加如下内容，修改 `path_alist` 为 AList 所在的路径，`path/to/working/dir` 为 AList的工作路径
 
 ```conf
@@ -141,6 +141,10 @@ WantedBy=multi-user.target
 - 开启: `launchctl start ~/Library/LaunchAgents/ci.nn.alist`
 - 关闭: `launchctl stop ~/Library/LaunchAgents/ci.nn.alist`
 - 卸载配置: `launchctl unload ~/Library/LaunchAgents/ci.nn.alist`
+@tab Windows
+任何你了解的方式，此处不再提供。
+:::
+
 
 ### 如何更新
 

--- a/docs/zh/guide/install/manual.md
+++ b/docs/zh/guide/install/manual.md
@@ -86,7 +86,7 @@ alist restart
 @tab Linux
 使用任意方式编辑 `/usr/lib/systemd/system/alist.service` 并添加如下内容，其中 path_alist 为 AList 所在的路径
 
-```conf
+```ini
 [Unit]
 Description=alist
 After=network.target
@@ -109,10 +109,11 @@ WantedBy=multi-user.target
 - 取消开机自启: `systemctl disable alist`
 - 状态: `systemctl status alist`
 - 重启: `systemctl restart alist`
+
 @tab macOS
 使用任意方式编辑 `~/Library/LaunchAgents/ci.nn.alist.plist` 并添加如下内容，修改 `path_alist` 为 AList 所在的路径，`path/to/working/dir` 为 AList的工作路径
 
-```conf
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -142,7 +143,9 @@ WantedBy=multi-user.target
 - 关闭: `launchctl stop ~/Library/LaunchAgents/ci.nn.alist`
 - 卸载配置: `launchctl unload ~/Library/LaunchAgents/ci.nn.alist`
 @tab Windows
+
 任何你了解的方式，此处不再提供。
+
 :::
 
 


### PR DESCRIPTION
使用MacOS自带的launchctl，开启守护进程，并开机自启动