### PR TITLE
Use the new Github proxy source

### DIFF
--- a/docs/.vuepress/public/v2.sh
+++ b/docs/.vuepress/public/v2.sh
@@ -22,7 +22,7 @@ BLUE_COLOR='\e[1;34m'
 PINK_COLOR='\e[1;35m'
 SHAN='\e[1;33;5m'
 RES='\e[0m'
-GH_PROXY='https://github.abskoop.workers.dev/'
+GH_PROXY='https://gh-proxy.com/'
 clear
 
 # Get platform

--- a/docs/.vuepress/public/v3.sh
+++ b/docs/.vuepress/public/v3.sh
@@ -40,7 +40,7 @@ elif [ "$platform" = "aarch64" ]; then
   ARCH=arm64
 fi
 
-GH_PROXY='https://github.abskoop.workers.dev/'
+GH_PROXY='https://gh-proxy.com/'
 
 if [ "$(id -u)" != "0" ]; then
   echo -e "\r\n${RED_COLOR}出错了，请使用 root 权限重试！${RES}\r\n" 1>&2


### PR DESCRIPTION
Use https://gh-proxy.com/ instead of https://github.abskoop.workers.dev/ to resolve the issue where workers.dev domain is blocked in Chinese mainland and cannot be downloaded