### PR TITLE
Update reverse-proxy.md 反向代理http3兼容

### DIFF
--- a/docs/guide/install/reverse-proxy.md
+++ b/docs/guide/install/reverse-proxy.md
@@ -33,10 +33,10 @@ Add in the server field of the website configuration file
 location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $host:$server_port;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header Range $http_range;
-	  proxy_set_header If-Range $http_if_range;
+    proxy_set_header If-Range $http_if_range;
     proxy_redirect off;
     proxy_pass http://127.0.0.1:5244;
     # the max size of file to upload


### PR DESCRIPTION
nginx 添加 http3 请求头,
`add_header Alt-Svc 'h3=":$server_port"; ma=86400'; `
反向代理使用 `$http_host` 会导致 alist 报错
`400 Bad Request: missing required Host header`
使用 `$host:$server_port` 替代, `$server_port` 是 nginx 监听的端口