### PR TITLE
Update offline-download.md for default qbittorrent path.

### DIFF
--- a/docs/zh/guide/advanced/offline-download.md
+++ b/docs/zh/guide/advanced/offline-download.md
@@ -35,7 +35,7 @@ star: true
 
 - **/opt/alist/data/temp/aria2**
 
-- **/opt/alist/data/temp/qbittorrent**
+- **/opt/alist/data/temp/qBittorrent**
 
 :::
 


### PR DESCRIPTION
v3.34.0，离线下载默认添加的这个路径，B是大写的，卡了我好久，有点坑。
![image](https://github.com/alist-org/docs/assets/46225881/a03862ef-a07e-4b33-97ed-154dd20be6bf)
不能直接按文档复制哈。