### PR TITLE
增加一处使用宝塔面板时应该修改的配置文件

### DIFF
--- a/docs/guide/install/reverse-proxy.md
+++ b/docs/guide/install/reverse-proxy.md
@@ -52,6 +52,12 @@ If you use the bt.cn, be sure to delete the following default configuration
 :::
 
 
+Disable Nginx caching in `/www/server/nginx/conf/proxy.conf` or the corresponding website configuration file. Otherwise, with the default configuration, when accessing large files, Nginx will attempt to cache the remote file locally first, resulting in playback failures.
+```conf
+proxy_cache cache_one; # Remove this line
+proxy_max_temp_file_size 0; # Add this line
+```
+
 ### **Apache**
 Add the anti-generation configuration item ProxyPass under the VirtualHost field, such as:
 ```xml

--- a/docs/zh/guide/install/reverse-proxy.md
+++ b/docs/zh/guide/install/reverse-proxy.md
@@ -56,6 +56,13 @@ location / {
 - location ~ .\*\.(js|css)?$
 ```
 
+并在`/www/server/nginx/conf/proxy.conf`中或对应网站配置文件中设置禁用Nginx缓存，否则默认配置下访问较大文件时Nginx会先尝试将远程文件缓存至本机，导致播放失败
+
+```conf
+proxy_cache cache_one; # 删除这一行
+proxy_max_temp_file_size 0; #加上这一行
+```
+
 :::
 
 ## **Apache**


### PR DESCRIPTION
宝塔面板默认对Nginx反向代理开启了缓存，在执行普通的API请求或访问小文件时不会有问题。

但通过反向代理在线播放较大的视频时由于其缓存策略原因导致浏览器虽然成功建立了连接并得到206响应代码，但始终无法获得到数据。多次超时后播放失败。

禁用Nginx缓存后较大视频文件也能直接播放。


软件版本：Alist V3
储存策略：OneDrive（开启本地代理）