### PR TITLE
向 ecosystem 增加一个整合了 Aria2 和 qBit 的 Alist 容器 

### DIFF
--- a/ecosystem.json
+++ b/ecosystem.json
@@ -22,6 +22,7 @@
     { "type": "github", "repo": "xlist-io/xlist" },
     { "type": "github", "repo": "j4587698/AListSdkSharp" },
     { "type": "github", "repo": "ShiroNeri4u/Neribox" },
-    { "type": "github", "repo": "synctv-org/synctv" }
+    { "type": "github", "repo": "synctv-org/synctv" },
+    { "type": "github", "repo": "wy580477/Alist-EX-container" } 
   ]
 }


### PR DESCRIPTION
和已有的 alist-aria2-pro-docker-compose 路线不同，单容器方案，部署设置简单一些。